### PR TITLE
Add PostCSS config

### DIFF
--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- add PostCSS configuration in `web` for Tailwind and autoprefixer

## Testing
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1ad961d08327ac60437f589fd5a3