### PR TITLE
Fix login redirect

### DIFF
--- a/web/pages/login.tsx
+++ b/web/pages/login.tsx
@@ -1,11 +1,37 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 import { Auth } from '@supabase/auth-ui-react'
 import { ThemeSupa } from '@supabase/auth-ui-shared'
 import { supabase } from '../lib/supabase'
 
 export default function Login() {
+  const router = useRouter()
+
+  // Redirect to the dashboard once a session is available
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) router.replace('/dashboard')
+    })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) router.replace('/dashboard')
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [router])
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 p-8">
-      <Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} theme="default" providers={[]} />
+      <Auth
+        supabaseClient={supabase}
+        appearance={{ theme: ThemeSupa }}
+        theme="default"
+        providers={[]}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- ensure users go to the dashboard when they have a valid session

## Testing
- `npm install`
- `CI=true npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: `supabaseUrl is required`)*

------
https://chatgpt.com/codex/tasks/task_e_684c25ec9ea883278bc444b885b77e1e