### PR TITLE
Add filters and color tags for cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This project contains a minimal web and mobile application skeleton for the Busy
 This repository is only a starting point and does not include installed dependencies.
 Make sure to run `npm install` (or `pnpm install`) inside each directory before development.
 
+## Features
+
+- Create and manage "thought" and "learning" cards.
+- Cards are color coded by type and can be filtered by type, year, month and tag on the dashboard.
+
 ## Prerequisites
 
 - A stable Node.js version (Node 18 or later is recommended).


### PR DESCRIPTION
## Summary
- add color coding and filtering controls to dashboard
- update README with feature list

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run test` in web *(prints 'No tests specified')*

------
https://chatgpt.com/codex/tasks/task_e_684c2cc9aea883279551d26869452b4c