### PR TITLE
Limit cards to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Make sure to run `npm install` (or `pnpm install`) inside each directory before 
 
 ## Features
 
-- Create and manage "thought" and "learning" cards.
-- Cards are color coded by type and can be filtered by type, year, month and tag on the dashboard.
+ - Create and manage "thought" and "learning" cards.
+ - Cards are color coded by type and can be filtered by type, year, month and tag on the dashboard.
+ - Each user only sees their own cards after signing in.
 
 ## Prerequisites
 

--- a/web/components/CardForm.tsx
+++ b/web/components/CardForm.tsx
@@ -26,7 +26,16 @@ export default function CardForm({ type, onCreated }: Props) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!title) return
-    await supabase.from('cards').insert({ title, description, tag, type })
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    await supabase.from('cards').insert({
+      title,
+      description,
+      tag,
+      type,
+      user_id: user?.id,
+    })
     setTitle('')
     setDescription('')
     setTag('')

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -19,7 +19,14 @@ export default function Dashboard() {
   const [tagFilter, setTagFilter] = useState('')
 
   const fetchData = async () => {
-    const { data } = await supabase.from('cards').select('*').order('created_at', { ascending: false })
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    const { data } = await supabase
+      .from('cards')
+      .select('*')
+      .eq('user_id', user?.id)
+      .order('created_at', { ascending: false })
     if (data) setCards(data as Card[])
   }
 


### PR DESCRIPTION
## Summary
- restrict fetch to current user's cards
- insert current user's ID when creating cards
- mention feed privacy in README

## Testing
- `npm test` in `web`
- `npm test` in `mobile`


------
https://chatgpt.com/codex/tasks/task_e_684c304d7ca083278cb80ef6f353f060