### PR TITLE
Improve web aesthetics

### DIFF
--- a/web/components/CardForm.tsx
+++ b/web/components/CardForm.tsx
@@ -43,22 +43,22 @@ export default function CardForm({ type, onCreated }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded bg-white shadow">
+    <form onSubmit={handleSubmit} className="space-y-3 border border-accent/50 p-6 rounded-xl bg-white/70 shadow">
       <h2 className="font-semibold capitalize">Create {type}</h2>
       <input
         type="text"
         placeholder="Title"
         value={title}
         onChange={e => setTitle(e.target.value)}
-        className="border w-full p-2 rounded"
+        className="border w-full p-2 rounded-md"
       />
       <textarea
         placeholder="Description"
         value={description}
         onChange={e => setDescription(e.target.value)}
-        className="border w-full p-2 rounded"
+        className="border w-full p-2 rounded-md"
       />
-      <select value={tag} onChange={e => setTag(e.target.value)} className="border w-full p-2 rounded">
+      <select value={tag} onChange={e => setTag(e.target.value)} className="border w-full p-2 rounded-md bg-white">
         <option value="" disabled>
           Select tag
         </option>
@@ -68,7 +68,7 @@ export default function CardForm({ type, onCreated }: Props) {
           </option>
         ))}
       </select>
-      <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+      <button type="submit" className="bg-primary text-white px-4 py-2 rounded-full hover:bg-primary/80">
         Add
       </button>
     </form>

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -58,31 +58,31 @@ export default function Dashboard() {
   })
 
   return (
-    <div className="min-h-screen p-4 max-w-xl mx-auto space-y-4">
+    <div className="min-h-screen p-4 max-w-2xl mx-auto space-y-6">
       <div className="flex justify-end">
-        <button onClick={signOut} className="text-sm text-blue-600 underline">
+        <button onClick={signOut} className="text-sm text-primary underline">
           Log Out
         </button>
       </div>
       <div className="grid grid-cols-2 gap-2">
-        <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="border p-2 rounded">
+        <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="border p-2 rounded-md bg-white">
           <option value="">All Types</option>
           <option value="thought">Thought</option>
           <option value="learning">Learning</option>
         </select>
-        <select value={yearFilter} onChange={e => setYearFilter(e.target.value)} className="border p-2 rounded">
+        <select value={yearFilter} onChange={e => setYearFilter(e.target.value)} className="border p-2 rounded-md bg-white">
           <option value="">All Years</option>
           {years.map(y => (
             <option key={y} value={y}>{y}</option>
           ))}
         </select>
-        <select value={monthFilter} onChange={e => setMonthFilter(e.target.value)} className="border p-2 rounded">
+        <select value={monthFilter} onChange={e => setMonthFilter(e.target.value)} className="border p-2 rounded-md bg-white">
           <option value="">All Months</option>
           {[...Array(12)].map((_, i) => (
             <option key={i+1} value={i+1}>{i+1}</option>
           ))}
         </select>
-        <select value={tagFilter} onChange={e => setTagFilter(e.target.value)} className="border p-2 rounded">
+        <select value={tagFilter} onChange={e => setTagFilter(e.target.value)} className="border p-2 rounded-md bg-white">
           <option value="">All Tags</option>
           {tags.map(t => (
             <option key={t} value={t}>{t}</option>
@@ -92,10 +92,10 @@ export default function Dashboard() {
       {filteredCards.map(card => (
         <div
           key={card.id}
-          className={`border p-4 rounded shadow-sm bg-white ${
+          className={`border p-4 rounded-xl shadow-sm bg-white/70 ${
             card.type === 'thought'
-              ? 'border-blue-500 bg-blue-50'
-              : 'border-green-500 bg-green-50'
+              ? 'border-primary/60'
+              : 'border-green-400'
           }`}
         >
           <div className="flex justify-between">
@@ -106,8 +106,8 @@ export default function Dashboard() {
           </div>
           <p className="text-sm text-gray-500 flex items-center space-x-2">
             <span
-              className={`text-white text-xs px-2 py-1 rounded ${
-                card.type === 'thought' ? 'bg-blue-500' : 'bg-green-500'
+              className={`text-white text-xs px-2 py-1 rounded-full ${
+                card.type === 'thought' ? 'bg-primary' : 'bg-green-500'
               }`}
             >
               {card.type}
@@ -120,8 +120,10 @@ export default function Dashboard() {
         </div>
       ))}
 
-      <CardForm type="thought" onCreated={fetchData} />
-      <CardForm type="learning" onCreated={fetchData} />
+      <div className="space-y-4">
+        <CardForm type="thought" onCreated={fetchData} />
+        <CardForm type="learning" onCreated={fetchData} />
+      </div>
     </div>
   )
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -2,15 +2,15 @@ import Link from 'next/link'
 
 export default function Home() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-8">
-      <div className="text-center space-y-4">
-        <h1 className="text-4xl font-serif">Busy Minds</h1>
-        <p className="max-w-md mx-auto text-gray-600">
-          An oasis for fast, idea-filled minds to organize thoughts and learnings.
+    <div className="min-h-screen flex items-center justify-center p-8">
+      <div className="text-center space-y-6 bg-white/60 rounded-3xl p-10 shadow-md">
+        <h1 className="text-5xl font-semibold text-gray-800 tracking-tight">Busy Minds</h1>
+        <p className="max-w-md mx-auto text-gray-600 text-lg">
+          Your calm space to capture thoughts and cherished learnings.
         </p>
         <Link
           href="/login"
-          className="inline-block bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          className="inline-block bg-primary text-white px-6 py-3 rounded-full hover:bg-primary/80"
         >
           Sign Up / Log In
         </Link>

--- a/web/pages/login.tsx
+++ b/web/pages/login.tsx
@@ -25,13 +25,15 @@ export default function Login() {
   }, [router])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-8">
-      <Auth
-        supabaseClient={supabase}
-        appearance={{ theme: ThemeSupa }}
-        theme="default"
-        providers={[]}
-      />
+    <div className="min-h-screen flex items-center justify-center p-8">
+      <div className="bg-white/60 rounded-3xl p-8 shadow-md w-full max-w-md">
+        <Auth
+          supabaseClient={supabase}
+          appearance={{ theme: ThemeSupa }}
+          theme="default"
+          providers={[]}
+        />
+      </div>
     </div>
   )
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,3 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans text-gray-700 bg-gradient-to-br from-sky-50 to-indigo-50;
+  }
+}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -5,7 +5,15 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}'
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['\'Nunito\'', 'sans-serif'],
+      },
+      colors: {
+        primary: '#5b8ef7',
+        accent: '#a8b9ff',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- import Nunito font and add gradient background
- expand Tailwind theme with custom fonts and colors
- soften CardForm components
- redesign login, landing page and dashboard

## Testing
- `npm test --silent`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3689e5108327bbf83c33d844a535