### PR TITLE
Update dashboard UX with modal forms

### DIFF
--- a/web/components/CardForm.tsx
+++ b/web/components/CardForm.tsx
@@ -4,11 +4,12 @@ import { supabase } from '../lib/supabase'
 type CardType = 'thought' | 'learning'
 
 interface Props {
-  type: CardType
+  type?: CardType
   onCreated: () => void
 }
 
-export default function CardForm({ type, onCreated }: Props) {
+export default function CardForm({ type: definedType, onCreated }: Props) {
+  const [type, setType] = useState<CardType>(definedType ?? 'thought')
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [tag, setTag] = useState('')
@@ -44,7 +45,17 @@ export default function CardForm({ type, onCreated }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3 border border-accent/50 p-6 rounded-xl bg-white/70 shadow">
-      <h2 className="font-semibold capitalize">Create {type}</h2>
+      {!definedType && (
+        <select
+          value={type}
+          onChange={e => setType(e.target.value as CardType)}
+          className="border w-full p-2 rounded-md bg-white"
+        >
+          <option value="thought">Thought</option>
+          <option value="learning">Learning</option>
+        </select>
+      )}
+      {definedType && <h2 className="font-semibold capitalize">Create {definedType}</h2>}
       <input
         type="text"
         placeholder="Title"
@@ -74,3 +85,4 @@ export default function CardForm({ type, onCreated }: Props) {
     </form>
   )
 }
+

--- a/web/components/CardModal.tsx
+++ b/web/components/CardModal.tsx
@@ -1,0 +1,22 @@
+import CardForm from './CardForm'
+
+interface Props {
+  onClose: () => void
+  onCreated: () => void
+}
+
+export default function CardModal({ onClose, onCreated }: Props) {
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-lg relative">
+        <CardForm onCreated={() => { onCreated(); onClose(); }} />
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,8 @@
         "@supabase/supabase-js": "^2.39.3",
         "next": "^14.0.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-icons": "^4.10.1"
       },
       "devDependencies": {
         "@types/react": "19.1.8",
@@ -1591,6 +1592,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,8 @@
     "@supabase/supabase-js": "^2.39.3",
     "next": "^14.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-icons": "^4.10.1"
   },
   "devDependencies": {
     "@types/react": "19.1.8",

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
-import CardForm from '../components/CardForm'
+import CardModal from '../components/CardModal'
+import { FaBrain } from 'react-icons/fa'
+import { FiMenu, FiTrash } from 'react-icons/fi'
 
 interface Card {
   id: number
@@ -17,11 +19,15 @@ export default function Dashboard() {
   const [yearFilter, setYearFilter] = useState('')
   const [monthFilter, setMonthFilter] = useState('')
   const [tagFilter, setTagFilter] = useState('')
+  const [showForm, setShowForm] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [userEmail, setUserEmail] = useState('')
 
   const fetchData = async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser()
+    if (user) setUserEmail(user.email ?? '')
     const { data } = await supabase
       .from('cards')
       .select('*')
@@ -59,30 +65,72 @@ export default function Dashboard() {
 
   return (
     <div className="min-h-screen p-4 max-w-2xl mx-auto space-y-6">
-      <div className="flex justify-end">
-        <button onClick={signOut} className="text-sm text-primary underline">
-          Log Out
-        </button>
+      <div className="flex justify-between items-center">
+        <div className="flex items-center space-x-2 text-xl font-semibold">
+          <FaBrain className="text-pink-500" />
+          <span>Busy Minds</span>
+        </div>
+        <div className="flex items-center space-x-4">
+          <button
+            onClick={() => setShowForm(true)}
+            className="bg-primary text-white px-4 py-2 rounded-full hover:bg-primary/80"
+          >
+            Add
+          </button>
+          <div className="relative">
+            <button onClick={() => setMenuOpen(!menuOpen)} className="text-2xl">
+              <FiMenu />
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 bg-white shadow rounded-md mt-2 text-sm">
+                <p className="px-4 py-2 border-b">{userEmail}</p>
+                <button
+                  onClick={signOut}
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                >
+                  Log Out
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
-      <div className="grid grid-cols-2 gap-2">
-        <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="border p-2 rounded-md bg-white">
+
+      <div className="flex flex-wrap gap-2">
+        <select
+          value={typeFilter}
+          onChange={e => setTypeFilter(e.target.value)}
+          className={`border p-2 rounded-md bg-white ${typeFilter ? 'border-primary' : ''}`}
+        >
           <option value="">All Types</option>
           <option value="thought">Thought</option>
           <option value="learning">Learning</option>
         </select>
-        <select value={yearFilter} onChange={e => setYearFilter(e.target.value)} className="border p-2 rounded-md bg-white">
+        <select
+          value={yearFilter}
+          onChange={e => setYearFilter(e.target.value)}
+          className={`border p-2 rounded-md bg-white ${yearFilter ? 'border-primary' : ''}`}
+        >
           <option value="">All Years</option>
           {years.map(y => (
             <option key={y} value={y}>{y}</option>
           ))}
         </select>
-        <select value={monthFilter} onChange={e => setMonthFilter(e.target.value)} className="border p-2 rounded-md bg-white">
+        <select
+          value={monthFilter}
+          onChange={e => setMonthFilter(e.target.value)}
+          className={`border p-2 rounded-md bg-white ${monthFilter ? 'border-primary' : ''}`}
+        >
           <option value="">All Months</option>
           {[...Array(12)].map((_, i) => (
             <option key={i+1} value={i+1}>{i+1}</option>
           ))}
         </select>
-        <select value={tagFilter} onChange={e => setTagFilter(e.target.value)} className="border p-2 rounded-md bg-white">
+        <select
+          value={tagFilter}
+          onChange={e => setTagFilter(e.target.value)}
+          className={`border p-2 rounded-md bg-white ${tagFilter ? 'border-primary' : ''}`}
+        >
           <option value="">All Tags</option>
           {tags.map(t => (
             <option key={t} value={t}>{t}</option>
@@ -100,8 +148,8 @@ export default function Dashboard() {
         >
           <div className="flex justify-between">
             <h3 className="font-semibold">{card.title}</h3>
-            <button onClick={() => handleDelete(card.id)} className="text-red-500">
-              Delete
+            <button onClick={() => handleDelete(card.id)} className="text-red-500 hover:text-red-700" title="Delete">
+              <FiTrash />
             </button>
           </div>
           <p className="text-sm text-gray-500 flex items-center space-x-2">
@@ -120,10 +168,20 @@ export default function Dashboard() {
         </div>
       ))}
 
-      <div className="space-y-4">
-        <CardForm type="thought" onCreated={fetchData} />
-        <CardForm type="learning" onCreated={fetchData} />
-      </div>
+      {filteredCards.length === 0 && (
+        <div className="text-center py-10 space-y-4">
+          <FaBrain className="mx-auto text-pink-500" size={48} />
+          <p className="text-gray-500">There is no thought or learning</p>
+          <button
+            onClick={() => setShowForm(true)}
+            className="bg-primary text-white px-4 py-2 rounded-full hover:bg-primary/80"
+          >
+            Add
+          </button>
+        </div>
+      )}
+
+      {showForm && <CardModal onClose={() => setShowForm(false)} onCreated={fetchData} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `react-icons` package
- refactor `CardForm` to optionally show type selector
- create reusable `CardModal` for adding cards in a popup
- redesign dashboard with header, menu and filters in one line
- show empty state with friendly message and add button

## Testing
- `npm --prefix web run lint` *(fails: prompts for config)*
- `npm --prefix web run test`

------
https://chatgpt.com/codex/tasks/task_e_684c3a1c2764832796a0597f6c473631